### PR TITLE
Fix num of iterations in mul256_bignum_640k.c

### DIFF
--- a/src/mul256_bignum_640000.c
+++ b/src/mul256_bignum_640000.c
@@ -40,7 +40,7 @@ void _main(){
   callDataCopy(x, 4, 32);
   callDataCopy(y, 36, 32);
 
-  for( int i=0; i<1000000; ++i ){
+  for( int i=0; i<10000; ++i ){
     mul256(y,x,z); mul256(y,z,x); mul256(y,x,z); mul256(y,z,x);
     mul256(y,x,z); mul256(y,z,x); mul256(y,x,z); mul256(y,z,x);
     mul256(y,x,z); mul256(y,z,x); mul256(y,x,z); mul256(y,z,x);


### PR DESCRIPTION
When testing I noticed this module was actually doing 64 mil iterations. Not sure if this is intentional.